### PR TITLE
Add Cocoapods compatibility

### DIFF
--- a/AzureBot.podspec
+++ b/AzureBot.podspec
@@ -1,0 +1,138 @@
+#
+#  Be sure to run `pod spec lint Beat.podspec' to ensure this is a
+#  valid spec and to remove all comments including this before submitting the spec.
+#
+#  To learn more about Podspec attributes see http://docs.cocoapods.org/specification.html
+#  To see working Podspecs in the CocoaPods repo see https://github.com/CocoaPods/Specs/
+#
+
+Pod::Spec.new do |s|
+
+  # ―――  Spec Metadata  ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  These will help people to find your library, and whilst it
+  #  can feel like a chore to fill in it's definitely to your advantage. The
+  #  summary should be tweet-length, and the description more in depth.
+  #
+
+  s.name         = "AzureBot"
+  s.version      = "0.0.1"
+  s.summary      = "Swift library to use Microsoft Bot Framework services"
+
+  # This description is used to generate tags and improve search results.
+  #   * Think: What does it do? Why did you write it? What is the focus?
+  #   * Try to keep it short, snappy and to the point.
+  #   * Write the description between the DESC delimiters below.
+  #   * Finally, don't worry about the indent, CocoaPods strips it!
+  s.description  = <<-DESC
+                     AzureBot is an iOS SDK for embedding a bot created using Microsoft Bot Framework.
+                   DESC
+
+  s.homepage     = "http://www.colbylwilliams.com/"
+  # s.screenshots  = "www.example.com/screenshots_1.gif", "www.example.com/screenshots_2.gif"
+
+
+  # ―――  Spec License  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Licensing your code is important. See http://choosealicense.com for more info.
+  #  CocoaPods will detect a license file if there is a named LICENSE*
+  #  Popular ones are 'MIT', 'BSD' and 'Apache License, Version 2.0'.
+  #
+
+  s.license      = "MIT"
+  # s.license      = { :type => "MIT", :file => "LICENSE.txt" }
+
+
+  # ――― Author Metadata  ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the authors of the library, with email addresses. Email addresses
+  #  of the authors are extracted from the SCM log. E.g. $ git log. CocoaPods also
+  #  accepts just a name if you'd rather not provide an email address.
+  #
+  #  Specify a social_media_url where others can refer to, for example a twitter
+  #  profile URL.
+  #
+
+  s.author    = "Colby Williams"
+  s.social_media_url   = "https://github.com/colbylwilliams"
+
+  # ――― Platform Specifics ――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If this Pod runs only on iOS or OS X, then specify the platform and
+  #  the deployment target. You can optionally include the target after the platform.
+  #
+
+  # s.platform     = :ios
+  # s.platform     = :ios, "11.0"
+
+  #  When using multiple platforms
+  s.ios.deployment_target = "11.0"
+  # s.osx.deployment_target = "10.10"
+  # s.watchos.deployment_target = "2.0"
+  # s.tvos.deployment_target = "9.0"
+
+
+  # ――― Source Location ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Specify the location from where the source should be retrieved.
+  #  Supports git, hg, bzr, svn and HTTP.
+  #
+
+  s.source       = { :git => "https://github.com/colbylwilliams/AzureBot.git", :tag => "#{s.version}" }
+
+
+  # ――― Source Code ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  CocoaPods is smart about how it includes source code. For source files
+  #  giving a folder will include any swift, h, m, mm, c & cpp files.
+  #  For header files it will include any header in the folder.
+  #  Not including the public_header_files will make all headers public.
+  #
+
+  s.source_files  = "Classes", "Classes/**/*.{h,m}", "Sources/**/*.swift", "AzureBot/Source/**/*.swift"
+  s.exclude_files = "Classes/Exclude"
+
+  # s.public_header_files = "Classes/**/*.h"
+
+
+  # ――― Resources ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  A list of resources included with the Pod. These are copied into the
+  #  target bundle with a build phase script. Anything else will be cleaned.
+  #  You can preserve files from being cleaned, please don't preserve
+  #  non-essential files like tests, examples and documentation.
+  #
+
+  # s.resource  = "icon.png"
+  # s.resources = "Resources/*.png"
+
+  # s.preserve_paths = "FilesToSave", "MoreFilesToSave"
+
+
+  # ――― Project Linking ―――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  Link your library with frameworks, or libraries. Libraries do not include
+  #  the lib prefix of their name.
+  #
+
+  # s.framework  = "SomeFramework"
+  # s.frameworks = "SomeFramework", "AnotherFramework"
+
+  # s.library   = "iconv"
+  # s.libraries = "iconv", "xml2"
+
+
+  # ――― Project Settings ――――――――――――――――――――――――――――――――――――――――――――――――――――――――― #
+  #
+  #  If your library depends on compiler flags you can set them in the xcconfig hash
+  #  where they will only apply to your library. If you depend on other Podspecs
+  #  you can include multiple dependencies to ensure it works.
+
+  s.swift_version = "4.1"
+
+  # s.requires_arc = true
+
+  # s.xcconfig = { "HEADER_SEARCH_PATHS" => "$(SDKROOT)/usr/include/libxml2" }
+  s.dependency "Starscream", "~> 3.0.6"
+
+end

--- a/AzureBot/AzureBot.xcodeproj/project.pbxproj
+++ b/AzureBot/AzureBot.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		7793D516222D5BED00EF3C6F /* AzureBot.podspec in Resources */ = {isa = PBXBuildFile; fileRef = 7793D515222D5BED00EF3C6F /* AzureBot.podspec */; };
 		932FE64320DA8A4D0056CE77 /* AzureBot.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 932FE64220DA8A4D0056CE77 /* AzureBot.xcassets */; };
 		932FE64520DAA3BA0056CE77 /* MessageBar.swift in Sources */ = {isa = PBXBuildFile; fileRef = 932FE64420DAA3BA0056CE77 /* MessageBar.swift */; };
 		93381B6C20DD680700883D31 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93381B6B20DD680700883D31 /* LocationManager.swift */; };
@@ -43,6 +44,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		7793D515222D5BED00EF3C6F /* AzureBot.podspec */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text; name = AzureBot.podspec; path = ../AzureBot.podspec; sourceTree = "<group>"; };
 		932FE64220DA8A4D0056CE77 /* AzureBot.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = AzureBot.xcassets; sourceTree = "<group>"; };
 		932FE64420DAA3BA0056CE77 /* MessageBar.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MessageBar.swift; sourceTree = "<group>"; };
 		93381B6B20DD680700883D31 /* LocationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LocationManager.swift; sourceTree = "<group>"; };
@@ -94,6 +96,7 @@
 		9399EA8E20D96063000E24B4 = {
 			isa = PBXGroup;
 			children = (
+				7793D515222D5BED00EF3C6F /* AzureBot.podspec */,
 				9399EA9A20D96063000E24B4 /* Source */,
 				9399EAA520D96063000E24B4 /* Tests */,
 				9399EA9920D96063000E24B4 /* Products */,
@@ -259,6 +262,7 @@
 			files = (
 				9399EB0720D9F6E7000E24B4 /* AzureBot.storyboard in Resources */,
 				932FE64320DA8A4D0056CE77 /* AzureBot.xcassets in Resources */,
+				7793D516222D5BED00EF3C6F /* AzureBot.podspec in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/AzureBot/Cartfile.resolved
+++ b/AzureBot/Cartfile.resolved
@@ -1,1 +1,1 @@
-github "daltoniam/Starscream" "3.0.5"
+github "daltoniam/Starscream" "3.0.6"

--- a/README.md
+++ b/README.md
@@ -57,8 +57,21 @@ github "colbylwilliams/AzureBot"
 Run `carthage update` to build the framework and drag the built `AzureBot.framework` into your Xcode project.
 
 ### CocoaPods
+[CocoaPods](https://cocoapods.org/) manages library dependencies for your Xcode projects.
 
-_Coming soon_
+The dependencies for your projects are specified in a single text file called a Podfile. CocoaPods will resolve dependencies between libraries, fetch the resulting source code, then link it together in an Xcode workspace to build your project.
+
+You can install CocoaPods with the following command:
+
+```bash
+$ sudo gem install cocoapods
+```
+
+To integrate AzureBot into your Xcode project using CocoaPods, specify it in your [Podfile](https://guides.cocoapods.org/using/the-podfile.html)
+```
+pod 'AzureBot', :git => 'https://github.com/baillyjamy/AzureBot.git'
+```
+Run `pod install` to create your workspace. For more information, see the [documentation](https://guides.cocoapods.org/)
 
 ### Swift Package Manager
 


### PR DESCRIPTION
Hello,
I wrote a podspec file to make your project compatible with Cocoapods. I needed it to use the library in my project. I also updated the instructions for Cocoapods in the README.md

The best would be to deploy the library on Cocoapods repository and replace the following line :
```pod 'AzureBot', :git => 'https://github.com/baillyjamy/AzureBot.git'```
by :
```pod 'AzureBot', '~> 0.0.1'```

If you are interested, you must create a github release and follow these instructions: https://guides.cocoapods.org/making/getting-setup-with-trunk.html